### PR TITLE
patch/recursively-look-for-link: drill upwards from target to find parent 'a' tags

### DIFF
--- a/simple_gestures.js
+++ b/simple_gestures.js
@@ -22,7 +22,7 @@ var currentGesture = "", previousGesture = ""
 var pi = 3.14159
 var suppress = 1
 var myGests, gestureActionMap;
-var link, ls, myColor = "red", myWidth = 3
+var ls, myColor = "red", myWidth = 3
 var loaded = false
 var link = null
 
@@ -38,15 +38,7 @@ function onStart(event) {
     currentGesture = ""
     previousGesture = ""
     moved = false
-    if (event.target.href) {
-        link = event.target.href
-    }
-    else if (event.target.parentElement.href) {
-        link = event.target.parentElement.href
-    }
-    else {
-        link = null
-    }
+    link = determineLink(event.target, 10)
 }
 
 function onMove(event) {
@@ -170,3 +162,13 @@ function watchGestures(name) {
 }
 
 document.addEventListener('DOMContentLoaded', watchGestures);
+
+function determineLink(target, allowedDrillCount){
+    if (target.href) {
+        return target.href
+    }
+    if(target.parentElement && allowedDrillCount > 0){
+        return determineLink(target.parentElement, allowedDrillCount - 1)
+    }
+    return null
+}


### PR DESCRIPTION
# Add support to find `<a>` tags further up the tree

## Issue description
Gesture action 'Open new tab' can be started on a link, instead of a blank new tab, the link target/href should open.    
This works fine for:
  - direct tags like: `<a href='https://github.com'>link text</a>`
  - 1 level nested tags like: `<a href='https://github.com'><img src="https://placekitten.com/20/20"/></a>`
 
This did *not* work for: 
  - Links with nested html: like `<a href='https://github.com'><div><div><div> link text </div></div></div></a>`

### Expected
href of link is opened, 

### Actual
Blank new tab is opened

### Resolution
Recursively drill upwards, looking for the first parent `<a>` tag. 
I've picked an arbitrary cut-off of '10' levels to drill up. 
when no parent A tag is found within 10 parents, it will instead  default to null/blank new tab. 
      
**Example page:**      
https://jsfiddle.net/7sm5092y/1/


# Closing notes
Thank you for open-sourcing this project.         
I've been using another chrome-extensions that had been hijacked (and became spyware). I've found this one as a fine replacement.
I appreciate the work you've done with this extension, It greatly improves my day-to-day browsing. 